### PR TITLE
fix: 修正内部Token菜单名称与编码

### DIFF
--- a/src/main/resources/db/migrations/V20260726_02__rename_internal_token_management_menu.sql
+++ b/src/main/resources/db/migrations/V20260726_02__rename_internal_token_management_menu.sql
@@ -1,0 +1,21 @@
+USE os_base_organization;
+SET NAMES utf8mb4;
+
+-- 使用 UTF-8 十六进制字节写入名称，避免部署终端或客户端字符集造成二次转码。
+UPDATE base_org_menu
+SET name = CONVERT(0xE58685E983A8546F6B656EE7AEA1E79086 USING utf8mb4),
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 220;
+
+UPDATE base_org_menu
+SET name = CONVERT(0xE8BDAEE68DA2E58685E983A8546F6B656EE5AF86E992A5 USING utf8mb4),
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 221;
+
+UPDATE base_org_menu
+SET name = CONVERT(0xE98080E5BDB970726576696F7573E5AF86E992A5 USING utf8mb4),
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 222;


### PR DESCRIPTION
## 变更\n- 将一级菜单名称调整为「内部Token管理」\n- 同步规范轮换、退役按钮名称\n- 使用 UTF-8 十六进制字节写入，避免部署链路二次转码乱码\n\n## 验证\n- SQL diff 校验通过\n- 部署后通过 HEX(name) 校验 UTF-8 字节