### PR TITLE
feat: 整理研发与计次管理菜单

### DIFF
--- a/src/main/resources/db/migrations/V20260726_03__merge_usage_management_menus.sql
+++ b/src/main/resources/db/migrations/V20260726_03__merge_usage_management_menus.sql
@@ -1,0 +1,24 @@
+USE os_base_organization;
+SET NAMES utf8mb4;
+
+-- 将计次场景与使用统计收口为一个页面，按钮权限继续挂在菜单 126 下。
+UPDATE base_org_menu
+SET href = '/sysadmin/usage-management',
+    icon = 'collection-tag',
+    name = '计次管理',
+    description = '{"routeName":"UsageManagement","component":"sysadmin/usage-management/index","visible":1}',
+    order_num = 68,
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 126;
+
+-- 仅清理历史“使用统计”菜单，避免误删复用同一 ID 的其他菜单。
+DELETE role_menu
+FROM base_org_role_menu role_menu
+JOIN base_org_menu menu ON menu.id = role_menu.menu_id
+WHERE menu.id = 122
+  AND menu.href = '/sysadmin/usage-statistics';
+
+DELETE FROM base_org_menu
+WHERE id = 122
+  AND href = '/sysadmin/usage-statistics';

--- a/src/main/resources/db/migrations/V20260726_04__move_error_catalog_to_development.sql
+++ b/src/main/resources/db/migrations/V20260726_04__move_error_catalog_to_development.sql
@@ -1,0 +1,11 @@
+USE os_base_organization;
+SET NAMES utf8mb4;
+
+-- 错误码目录属于开发治理能力，页面路由和既有角色授权保持不变。
+UPDATE base_org_menu
+SET parent_id = 117,
+    order_num = 20,
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 186
+  AND href = '/sysadmin/error-catalog';

--- a/src/main/resources/db/migrations/V20260726_05__move_service_management_to_development.sql
+++ b/src/main/resources/db/migrations/V20260726_05__move_service_management_to_development.sql
@@ -1,0 +1,11 @@
+USE os_base_organization;
+SET NAMES utf8mb4;
+
+-- 服务目录面向研发人员，保留原页面路由和既有角色授权。
+UPDATE base_org_menu
+SET parent_id = 117,
+    order_num = 30,
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 201
+  AND href = '/gateway/services';

--- a/src/main/resources/db/os-base-org-ddl.sql
+++ b/src/main/resources/db/os-base-org-ddl.sql
@@ -337,7 +337,8 @@ VALUES (101, -1, 'MENU', '/admin', 'setting', '基础管理', '用户，角色�
        (121, 109, 'MENU', '/sysadmin/internal-messages', 'bell', '站内信管理', '{"routeName":"InternalMessage","component":"system/notice/index","visible":1}', 65, now(), now(), 'system', 'system'),
        (116, 108, 'MENU', '/auth/online-user', 'el-icon-User', '在线用户', '{"routeName":"OnlineUser","component":"security/online-user/index","visible":1}', 20, now(), now(), 'system', 'system'),
        (117, -1, 'MENU', '/development', 'code', '研发管理', '研发工具与接口文档', 90, now(), now(), 'system', 'system'),
-       (118, 117, 'MENU', '/development/api-docs', 'document', 'API文档', '{"iframeUrl":"/doc.html","visible":1}', 10, now(), now(), 'system', 'system');
+       (118, 117, 'MENU', '/development/api-docs', 'document', 'API文档', '{"iframeUrl":"/doc.html","visible":1}', 10, now(), now(), 'system', 'system'),
+       (186, 117, 'MENU', '/sysadmin/error-catalog', 'warning', '错误码目录', '{"routeName":"ErrorCatalog","component":"sysadmin/error-catalog/index","visible":1}', 20, now(), now(), 'system', 'system');
 
 INSERT INTO base_org_user_group (id, user_id, group_id, created_time, updated_time, created_by, updated_by)
 VALUES (101, 101, 101, now(), now(), 'system', 'system'),
@@ -392,7 +393,9 @@ VALUES (101, 101, 101, now(), now(), 'system', 'system'),
        (147, 101, 121, now(), now(), 'system', 'system'),
        (148, 103, 121, now(), now(), 'system', 'system'),
        (160, 101, 126, now(), now(), 'system', 'system'),
-       (161, 103, 126, now(), now(), 'system', 'system');
+       (161, 103, 126, now(), now(), 'system', 'system'),
+       (186, 101, 186, now(), now(), 'system', 'system'),
+       (187, 103, 186, now(), now(), 'system', 'system');
 
 -- 按钮菜单控制管理台可见性；API 授权数据仍由 base_org_resource 维护。
 INSERT INTO base_org_menu (id, parent_id, type, href, icon, name, description, order_num, created_time, updated_time, created_by, updated_by)

--- a/src/main/resources/db/os-base-org-ddl.sql
+++ b/src/main/resources/db/os-base-org-ddl.sql
@@ -309,7 +309,7 @@ VALUES (101, -1, 'MENU', '/admin', 'setting', '基础管理', '用户，角色�
        (114, 109, 'MENU', '/sysadmin/captcha-scenes', 'captcha', '验证码管理', '{"routeName":"CaptchaScenes","component":"sysadmin/captcha-scenes/index","visible":1}', 40, now(), now(), 'system', 'system'),
        (115, 109, 'MENU', '/sysadmin/notification', 'bell', '通知管理', '{"routeName":"NotificationAdmin","component":"sysadmin/notification/index","visible":1}', 50, now(), now(), 'system', 'system'),
        (119, 109, 'MENU', '/sysadmin/ratelimit-scenes', 'timer', '限次场景', '{"routeName":"RateLimitScenes","component":"sysadmin/ratelimit-scenes/index","visible":1}', 55, now(), now(), 'system', 'system'),
-       (126, 109, 'MENU', '/sysadmin/usage-scenes', 'collection-tag', '计次场景', '{"routeName":"UsageScenes","component":"sysadmin/usage-scenes/index","visible":1}', 68, now(), now(), 'system', 'system'),
+       (126, 109, 'MENU', '/sysadmin/usage-management', 'collection-tag', '计次管理', '{"routeName":"UsageManagement","component":"sysadmin/usage-management/index","visible":1}', 68, now(), now(), 'system', 'system'),
        (160, -1, 'MENU', '/gateway', 'api', '网关路由', '{"routeName":"Gateway","visible":1}', 85, now(), now(), 'system', 'system'),
        (200,160,'MENU','/gateway/dashboard','homepage','网关总览','{"routeName":"GatewayDashboard","component":"system/gateway/planned/index","visible":1}',10,now(),now(),'system','system'),
        (201,160,'MENU','/gateway/services','cluster','服务管理','{"routeName":"GatewayServices","component":"system/gateway/services/index","visible":1}',20,now(),now(),'system','system'),

--- a/src/main/resources/db/os-base-org-ddl.sql
+++ b/src/main/resources/db/os-base-org-ddl.sql
@@ -312,7 +312,7 @@ VALUES (101, -1, 'MENU', '/admin', 'setting', '基础管理', '用户，角色�
        (126, 109, 'MENU', '/sysadmin/usage-management', 'collection-tag', '计次管理', '{"routeName":"UsageManagement","component":"sysadmin/usage-management/index","visible":1}', 68, now(), now(), 'system', 'system'),
        (160, -1, 'MENU', '/gateway', 'api', '网关路由', '{"routeName":"Gateway","visible":1}', 85, now(), now(), 'system', 'system'),
        (200,160,'MENU','/gateway/dashboard','homepage','网关总览','{"routeName":"GatewayDashboard","component":"system/gateway/planned/index","visible":1}',10,now(),now(),'system','system'),
-       (201,160,'MENU','/gateway/services','cluster','服务管理','{"routeName":"GatewayServices","component":"system/gateway/services/index","visible":1}',20,now(),now(),'system','system'),
+       (201,117,'MENU','/gateway/services','cluster','服务管理','{"routeName":"GatewayServices","component":"system/gateway/services/index","visible":1}',30,now(),now(),'system','system'),
        (120,160,'MENU','/gateway/routes','api','路由管理','{"routeName":"GatewayRouteManagement","component":"system/gateway/route/index","visible":1}',30,now(),now(),'system','system'),
        (202,160,'MENU','/gateway/traffic','timer','流量治理','{"routeName":"GatewayTraffic","visible":1}',40,now(),now(),'system','system'),
        (217,202,'MENU','/gateway/traffic/rate-limits','timer','限流规则','{"routeName":"GatewayRateLimits","component":"system/gateway/planned/index","visible":1}',10,now(),now(),'system','system'),


### PR DESCRIPTION
## 变更\n- 计次场景与使用统计合并为计次管理\n- 错误码目录移动到研发管理\n- 服务管理移动到研发管理\n- 保留原页面路由、按钮权限和角色授权\n- 增加线上升级迁移与全新安装初始化数据