### PR TITLE
feat: 调整安全认证菜单结构

### DIFF
--- a/src/main/resources/db/migrations/V20260726_06__merge_token_management_tabs.sql
+++ b/src/main/resources/db/migrations/V20260726_06__merge_token_management_tabs.sql
@@ -1,0 +1,51 @@
+USE os_base_organization;
+SET NAMES utf8mb4;
+
+-- 客户端与 OAuth2 授权记录共享一个页面入口，终止授权权限继续由按钮菜单控制。
+UPDATE base_org_menu
+SET description = '{"routeName":"OAuthClientManagement","component":"auth/client-management/index","visible":1}',
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 110;
+
+INSERT INTO base_org_menu
+    (id, parent_id, type, href, icon, name, description, order_num,
+     created_time, updated_time, created_by, updated_by)
+VALUES
+    (220, 108, 'MENU', '/auth/internal-token-keys', 'key', '内部 Token 管理',
+     '{"routeName":"InternalTokenKeys","component":"sysadmin/internal-token-keys/index","visible":1}',
+     30, now(), now(), 'system', 'system'),
+    (221, 220, 'BUTTON', '', '', '轮换内部 Token 密钥',
+     '{"perm":"sysadmin:internal-token-key:rotate"}',
+     1, now(), now(), 'system', 'system'),
+    (222, 220, 'BUTTON', '', '', '退役 previous 密钥',
+     '{"perm":"sysadmin:internal-token-key:retire"}',
+     2, now(), now(), 'system', 'system'),
+    (231, 110, 'BUTTON', '', '', '终止 OAuth2 服务端授权',
+     '{"perm":"auth:authorization:revoke"}',
+     1, now(), now(), 'system', 'system')
+ON DUPLICATE KEY UPDATE
+    parent_id = VALUES(parent_id),
+    type = VALUES(type),
+    href = VALUES(href),
+    icon = VALUES(icon),
+    name = VALUES(name),
+    description = VALUES(description),
+    order_num = VALUES(order_num),
+    updated_time = now(),
+    updated_by = 'system';
+
+INSERT INTO base_org_role_menu
+    (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
+SELECT 100000 + role.id * 1000 + menu.id, role.id, menu.id,
+       now(), now(), 'system', 'system'
+FROM base_org_role role
+JOIN base_org_menu menu ON menu.id IN (220, 221, 222, 231)
+WHERE role.id IN (101, 103)
+ON DUPLICATE KEY UPDATE
+    updated_time = now(),
+    updated_by = 'system';
+
+-- 删除独立 Token 管理入口；API 资源与角色资源授权保持不变。
+DELETE FROM base_org_role_menu WHERE menu_id = 230;
+DELETE FROM base_org_menu WHERE id = 230;

--- a/src/main/resources/db/os-base-org-ddl.sql
+++ b/src/main/resources/db/os-base-org-ddl.sql
@@ -302,7 +302,7 @@ VALUES (101, -1, 'MENU', '/admin', 'setting', '基础管理', '用户，角色�
        (107, 101, 'MENU', '/admin/positions', 'project', '岗位管理', '岗位新增，修改，查看，删除', 60, now(), now(), 'system', 'system'),
        (108, -1, 'MENU', '/auth', 'client', '安全认证', '安全认证服务管理', 70, now(), now(), 'system', 'system'),
        (109, -1, 'MENU', '/sysadmin', 'document', '系统管理', '审计与系统运维管理', 80, now(), now(), 'system', 'system'),
-       (110, 108, 'MENU', '/auth/client', 'client', '客户端管理', 'OAuth2客户端新增，修改，删除', 10, now(), now(), 'system', 'system'),
+       (110, 108, 'MENU', '/auth/client', 'client', '客户端管理', '{"routeName":"OAuthClientManagement","component":"auth/client-management/index","visible":1}', 10, now(), now(), 'system', 'system'),
        (111, 109, 'MENU', '/sysadmin/audit-log', 'document', '审计日志', '审计日志查询，清理', 10, now(), now(), 'system', 'system'),
        (112, 109, 'MENU', '/sysadmin/dicts', 'dict', '字典管理', '{"routeName":"Dict","component":"system/dict/index","visible":1}', 20, now(), now(), 'system', 'system'),
        (113, 109, 'MENU', '/sysadmin/dict-items', 'dict', '字典项', '{"routeName":"DictItem","component":"system/dict/dict-item","visible":0}', 30, now(), now(), 'system', 'system'),
@@ -336,6 +336,7 @@ VALUES (101, -1, 'MENU', '/admin', 'setting', '基础管理', '用户，角色�
        (216,160,'MENU','/gateway/settings','setting','系统设置','{"routeName":"GatewaySettings","component":"system/gateway/planned/index","visible":1}',90,now(),now(),'system','system'),
        (121, 109, 'MENU', '/sysadmin/internal-messages', 'bell', '站内信管理', '{"routeName":"InternalMessage","component":"system/notice/index","visible":1}', 65, now(), now(), 'system', 'system'),
        (116, 108, 'MENU', '/auth/online-user', 'el-icon-User', '在线用户', '{"routeName":"OnlineUser","component":"security/online-user/index","visible":1}', 20, now(), now(), 'system', 'system'),
+       (220, 108, 'MENU', '/auth/internal-token-keys', 'key', '内部 Token 管理', '{"routeName":"InternalTokenKeys","component":"sysadmin/internal-token-keys/index","visible":1}', 30, now(), now(), 'system', 'system'),
        (117, -1, 'MENU', '/development', 'code', '研发管理', '研发工具与接口文档', 90, now(), now(), 'system', 'system'),
        (118, 117, 'MENU', '/development/api-docs', 'document', 'API文档', '{"iframeUrl":"/doc.html","visible":1}', 10, now(), now(), 'system', 'system'),
        (186, 117, 'MENU', '/sysadmin/error-catalog', 'warning', '错误码目录', '{"routeName":"ErrorCatalog","component":"sysadmin/error-catalog/index","visible":1}', 20, now(), now(), 'system', 'system');
@@ -408,7 +409,8 @@ VALUES (122, 109, 'MENU', '/sysadmin/configs', 'setting', '系统配置', '{"rou
        (143,116,'BUTTON','','','强制下线','{"perm":"security:online-user:kickout"}',1,now(),now(),'system','system'), (144,120,'BUTTON','','','新增网关路由','{"perm":"gateway:route:create"}',1,now(),now(),'system','system'), (145,120,'BUTTON','','','修改网关路由','{"perm":"gateway:route:update"}',2,now(),now(),'system','system'), (146,120,'BUTTON','','','删除网关路由','{"perm":"gateway:route:delete"}',3,now(),now(),'system','system'),
        (147,121,'BUTTON','','','创建站内信','{"perm":"sys:internal-message:create"}',1,now(),now(),'system','system'), (148,121,'BUTTON','','','修改站内信','{"perm":"sys:internal-message:update"}',2,now(),now(),'system','system'), (149,121,'BUTTON','','','删除站内信','{"perm":"sys:internal-message:delete"}',3,now(),now(),'system','system'), (150,121,'BUTTON','','','发布站内信','{"perm":"sys:internal-message:publish"}',4,now(),now(),'system','system'), (151,121,'BUTTON','','','撤回站内信','{"perm":"sys:internal-message:revoke"}',5,now(),now(),'system','system'),
        (152,122,'BUTTON','','','新增系统配置','{"perm":"sys:config:create"}',1,now(),now(),'system','system'), (153,122,'BUTTON','','','修改系统配置','{"perm":"sys:config:update"}',2,now(),now(),'system','system'), (154,122,'BUTTON','','','删除系统配置','{"perm":"sys:config:delete"}',3,now(),now(),'system','system'), (155,122,'BUTTON','','','刷新系统配置缓存','{"perm":"sys:config:refresh"}',4,now(),now(),'system','system'),
-       (156,123,'BUTTON','','','新增租户','{"perm":"sys:tenant:create"}',1,now(),now(),'system','system'), (157,123,'BUTTON','','','修改租户','{"perm":"sys:tenant:update"}',2,now(),now(),'system','system'), (158,123,'BUTTON','','','删除租户','{"perm":"sys:tenant:delete"}',3,now(),now(),'system','system'), (159,203,'BUTTON','','','发布 OAuth2 认证方式','{"perm":"gateway:oauth2-client:update"}',1,now(),now(),'system','system'), (164,205,'BUTTON','','','发布网关全局过滤器','{"perm":"gateway:filter:update"}',1,now(),now(),'system','system');
+       (156,123,'BUTTON','','','新增租户','{"perm":"sys:tenant:create"}',1,now(),now(),'system','system'), (157,123,'BUTTON','','','修改租户','{"perm":"sys:tenant:update"}',2,now(),now(),'system','system'), (158,123,'BUTTON','','','删除租户','{"perm":"sys:tenant:delete"}',3,now(),now(),'system','system'), (159,203,'BUTTON','','','发布 OAuth2 认证方式','{"perm":"gateway:oauth2-client:update"}',1,now(),now(),'system','system'), (164,205,'BUTTON','','','发布网关全局过滤器','{"perm":"gateway:filter:update"}',1,now(),now(),'system','system'),
+       (221,220,'BUTTON','','','轮换内部 Token 密钥','{"perm":"sysadmin:internal-token-key:rotate"}',1,now(),now(),'system','system'), (222,220,'BUTTON','','','退役 previous 密钥','{"perm":"sysadmin:internal-token-key:retire"}',2,now(),now(),'system','system'), (231,110,'BUTTON','','','终止 OAuth2 服务端授权','{"perm":"auth:authorization:revoke"}',1,now(),now(),'system','system');
 
 INSERT INTO base_org_role_menu (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
 SELECT 100000 + r.id * 1000 + m.id, r.id, m.id, now(), now(), 'system', 'system'
@@ -419,16 +421,4 @@ ON DUPLICATE KEY UPDATE updated_time=VALUES(updated_time), updated_by=VALUES(upd
 INSERT INTO base_org_role_menu (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
 SELECT 100000 + r.id * 1000 + m.id, r.id, m.id, now(), now(), 'system', 'system'
 FROM base_org_menu m JOIN base_org_role r ON r.id IN (101, 103)
-WHERE m.id IN (122, 123) OR m.id BETWEEN 130 AND 159;
-
-
--- OAuth2授权记录管理
-INSERT INTO base_org_menu (id, parent_id, type, href, icon, name, description, order_num, created_time, updated_time, created_by, updated_by)
-VALUES (230, 108, 'MENU', '/auth/authorization', 'key', 'Token管理', '{"routeName":"OAuthAuthorization","component":"auth/authorization/index","visible":1}', 20, now(), now(), 'system', 'system'),
-       (231, 230, 'BUTTON', '', '', '终止OAuth2服务端授权', '{"perm":"auth:authorization:revoke"}', 1, now(), now(), 'system', 'system');
-
-INSERT INTO base_org_role_menu (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
-VALUES (201230, 101, 230, now(), now(), 'system', 'system'),
-       (203230, 103, 230, now(), now(), 'system', 'system'),
-       (201231, 101, 231, now(), now(), 'system', 'system'),
-       (203231, 103, 231, now(), now(), 'system', 'system');
+WHERE m.id IN (122, 123, 220, 221, 222, 231) OR m.id BETWEEN 130 AND 159;

--- a/src/test/java/io/github/opensabre/organization/service/MenuServiceTest.java
+++ b/src/test/java/io/github/opensabre/organization/service/MenuServiceTest.java
@@ -22,15 +22,16 @@ class MenuServiceTest {
         assertThat(menus).extracting(MenuVo::getId).containsExactly("101", "108", "109", "160", "117");
         assertThat(menus).extracting(MenuVo::getName).containsExactly("基础管理", "安全认证", "系统管理", "网关路由", "研发管理");
         assertThat(menus.get(0).getChildren()).extracting(MenuVo::getId).containsExactly("102", "103", "104", "105", "106", "107", "123");
-        assertThat(menus.get(1).getChildren()).extracting(MenuVo::getId).containsExactly("110", "116");
+        assertThat(menus.get(1).getChildren()).extracting(MenuVo::getId).containsExactly("110", "116", "220");
         assertThat(menus.get(1).getChildren().get(1).getHref()).isEqualTo("/auth/online-user");
+        assertThat(menus.get(1).getChildren().get(2).getHref()).isEqualTo("/auth/internal-token-keys");
         assertThat(menus.get(2).getChildren()).extracting(MenuVo::getId).containsExactly("111", "112", "113", "114", "115", "119", "121", "126", "122");
         assertThat(menus.get(2).getHref()).isEqualTo("/sysadmin");
         assertThat(menus.get(2).getChildren().get(0).getHref()).isEqualTo("/sysadmin/audit-log");
         assertThat(menus.get(3).getChildren()).extracting(MenuVo::getId)
-                .containsExactly("200", "201", "120", "202", "161", "162", "207", "211", "216");
-        assertThat(menus.get(3).getChildren().get(2).getHref()).isEqualTo("/gateway/routes");
-        assertThat(menus.get(4).getChildren()).extracting(MenuVo::getId).containsExactly("118");
+                .containsExactly("200", "120", "202", "161", "162", "207", "211", "216");
+        assertThat(menus.get(3).getChildren().get(1).getHref()).isEqualTo("/gateway/routes");
+        assertThat(menus.get(4).getChildren()).extracting(MenuVo::getId).containsExactly("118", "186", "201");
         assertThat(menus.get(4).getChildren().get(0).getHref()).isEqualTo("/development/api-docs");
     }
 }


### PR DESCRIPTION
## 变更\n- 删除独立Token管理菜单并将终止授权按钮挂到客户端管理\n- 将内部Token管理作为安全认证二级菜单\n- 增加幂等数据库迁移并同步初始化DDL\n- 补齐最新菜单结构测试期望\n\n## 验证\n- mvn test：20项通过\n- 最新master重放后MenuServiceTest通过\n- git diff --check通过