### PR TITLE
feat: 增加 Token 清理权限菜单

### DIFF
--- a/src/main/resources/db/migrations/V20260727_01__rename_internal_auth_and_add_token_cleanup.sql
+++ b/src/main/resources/db/migrations/V20260727_01__rename_internal_auth_and_add_token_cleanup.sql
@@ -1,0 +1,67 @@
+USE os_base_organization;
+SET NAMES utf8mb4;
+
+-- 统一安全认证术语，并为失效授权记录清理提供独立的按钮与API权限。
+UPDATE base_org_menu
+SET name = '内部认证',
+    updated_time = now(),
+    updated_by = 'system'
+WHERE id = 220;
+
+INSERT INTO base_org_resource
+    (id, name, code, type, url, method, description,
+     created_time, updated_time, created_by, updated_by)
+VALUES
+    (333, '清理已失效OAuth2授权记录', 'auth:authorization:cleanup', 'authorization',
+     '/api/auth/authorizations/expired/cleanup', 'DELETE',
+     '删除所有Token、授权码和设备码均已过期的服务端授权记录',
+     now(), now(), 'system', 'system')
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    code = VALUES(code),
+    type = VALUES(type),
+    url = VALUES(url),
+    method = VALUES(method),
+    description = VALUES(description),
+    updated_time = now(),
+    updated_by = 'system';
+
+INSERT INTO base_org_menu
+    (id, parent_id, type, href, icon, name, description, order_num,
+     created_time, updated_time, created_by, updated_by)
+VALUES
+    (232, 110, 'BUTTON', '', '', '清理已失效 Token',
+     '{"perm":"auth:authorization:cleanup"}',
+     2, now(), now(), 'system', 'system')
+ON DUPLICATE KEY UPDATE
+    parent_id = VALUES(parent_id),
+    type = VALUES(type),
+    href = VALUES(href),
+    icon = VALUES(icon),
+    name = VALUES(name),
+    description = VALUES(description),
+    order_num = VALUES(order_num),
+    updated_time = now(),
+    updated_by = 'system';
+
+INSERT INTO base_org_role_resource
+    (id, role_id, resource_id, created_time, updated_time, created_by, updated_by)
+SELECT 100000 + role.id * 1000 + resource.id, role.id, resource.id,
+       now(), now(), 'system', 'system'
+FROM base_org_role role
+JOIN base_org_resource resource ON resource.id = 333
+WHERE role.id IN (101, 103)
+ON DUPLICATE KEY UPDATE
+    updated_time = now(),
+    updated_by = 'system';
+
+INSERT INTO base_org_role_menu
+    (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
+SELECT 100000 + role.id * 1000 + menu.id, role.id, menu.id,
+       now(), now(), 'system', 'system'
+FROM base_org_role role
+JOIN base_org_menu menu ON menu.id = 232
+WHERE role.id IN (101, 103)
+ON DUPLICATE KEY UPDATE
+    updated_time = now(),
+    updated_by = 'system';

--- a/src/main/resources/db/os-base-org-ddl.sql
+++ b/src/main/resources/db/os-base-org-ddl.sql
@@ -225,7 +225,8 @@ VALUES (101, '新增用户', 'user_manager:btn_add', 'user', '/user', 'POST', '�
        (323, '发布网关 OAuth2 认证方式', 'gateway:oauth2-client:update', 'gateway', '/gateway/routes/oauth2-clients', 'PUT', '更新并发布网关 OAuth2/OIDC 登录认证方式', now(), now(), 'system', 'system'),
        (330, '查询OAuth2授权记录', 'auth:authorization:query', 'authorization', '/api/auth/authorizations/conditions', 'POST', '分页查询OAuth2服务端授权记录', now(), now(), 'system', 'system'),
        (331, '查看OAuth2授权记录', 'auth:authorization:view', 'authorization', '/api/auth/authorizations/{id}', 'GET', '查看OAuth2服务端授权详情', now(), now(), 'system', 'system'),
-       (332, '终止OAuth2服务端授权', 'auth:authorization:revoke', 'authorization', '/api/auth/authorizations/{id}', 'DELETE', '删除服务端授权并阻止Refresh Token继续使用', now(), now(), 'system', 'system');
+       (332, '终止OAuth2服务端授权', 'auth:authorization:revoke', 'authorization', '/api/auth/authorizations/{id}', 'DELETE', '删除服务端授权并阻止Refresh Token继续使用', now(), now(), 'system', 'system'),
+       (333, '清理已失效OAuth2授权记录', 'auth:authorization:cleanup', 'authorization', '/api/auth/authorizations/expired/cleanup', 'DELETE', '删除所有Token、授权码和设备码均已过期的服务端授权记录', now(), now(), 'system', 'system');
 
 -- 用户关系授权
 INSERT INTO base_org_user_role (id, user_id, role_id, created_time, updated_time, created_by, updated_by)
@@ -275,7 +276,9 @@ VALUES (101, 101, 101, now(), now(), 'system', 'system'),
        (524, 101, 332, now(), now(), 'system', 'system'),
        (525, 103, 330, now(), now(), 'system', 'system'),
        (526, 103, 331, now(), now(), 'system', 'system'),
-       (527, 103, 332, now(), now(), 'system', 'system');
+       (527, 103, 332, now(), now(), 'system', 'system'),
+       (528, 101, 333, now(), now(), 'system', 'system'),
+       (529, 103, 333, now(), now(), 'system', 'system');
 
 -- 岗位
 INSERT INTO base_org_position (id, name, description, created_time, updated_time, created_by, updated_by)
@@ -336,7 +339,7 @@ VALUES (101, -1, 'MENU', '/admin', 'setting', '基础管理', '用户，角色�
        (216,160,'MENU','/gateway/settings','setting','系统设置','{"routeName":"GatewaySettings","component":"system/gateway/planned/index","visible":1}',90,now(),now(),'system','system'),
        (121, 109, 'MENU', '/sysadmin/internal-messages', 'bell', '站内信管理', '{"routeName":"InternalMessage","component":"system/notice/index","visible":1}', 65, now(), now(), 'system', 'system'),
        (116, 108, 'MENU', '/auth/online-user', 'el-icon-User', '在线用户', '{"routeName":"OnlineUser","component":"security/online-user/index","visible":1}', 20, now(), now(), 'system', 'system'),
-       (220, 108, 'MENU', '/auth/internal-token-keys', 'key', '内部 Token 管理', '{"routeName":"InternalTokenKeys","component":"sysadmin/internal-token-keys/index","visible":1}', 30, now(), now(), 'system', 'system'),
+       (220, 108, 'MENU', '/auth/internal-token-keys', 'key', '内部认证', '{"routeName":"InternalTokenKeys","component":"sysadmin/internal-token-keys/index","visible":1}', 30, now(), now(), 'system', 'system'),
        (117, -1, 'MENU', '/development', 'code', '研发管理', '研发工具与接口文档', 90, now(), now(), 'system', 'system'),
        (118, 117, 'MENU', '/development/api-docs', 'document', 'API文档', '{"iframeUrl":"/doc.html","visible":1}', 10, now(), now(), 'system', 'system'),
        (186, 117, 'MENU', '/sysadmin/error-catalog', 'warning', '错误码目录', '{"routeName":"ErrorCatalog","component":"sysadmin/error-catalog/index","visible":1}', 20, now(), now(), 'system', 'system');
@@ -410,7 +413,7 @@ VALUES (122, 109, 'MENU', '/sysadmin/configs', 'setting', '系统配置', '{"rou
        (147,121,'BUTTON','','','创建站内信','{"perm":"sys:internal-message:create"}',1,now(),now(),'system','system'), (148,121,'BUTTON','','','修改站内信','{"perm":"sys:internal-message:update"}',2,now(),now(),'system','system'), (149,121,'BUTTON','','','删除站内信','{"perm":"sys:internal-message:delete"}',3,now(),now(),'system','system'), (150,121,'BUTTON','','','发布站内信','{"perm":"sys:internal-message:publish"}',4,now(),now(),'system','system'), (151,121,'BUTTON','','','撤回站内信','{"perm":"sys:internal-message:revoke"}',5,now(),now(),'system','system'),
        (152,122,'BUTTON','','','新增系统配置','{"perm":"sys:config:create"}',1,now(),now(),'system','system'), (153,122,'BUTTON','','','修改系统配置','{"perm":"sys:config:update"}',2,now(),now(),'system','system'), (154,122,'BUTTON','','','删除系统配置','{"perm":"sys:config:delete"}',3,now(),now(),'system','system'), (155,122,'BUTTON','','','刷新系统配置缓存','{"perm":"sys:config:refresh"}',4,now(),now(),'system','system'),
        (156,123,'BUTTON','','','新增租户','{"perm":"sys:tenant:create"}',1,now(),now(),'system','system'), (157,123,'BUTTON','','','修改租户','{"perm":"sys:tenant:update"}',2,now(),now(),'system','system'), (158,123,'BUTTON','','','删除租户','{"perm":"sys:tenant:delete"}',3,now(),now(),'system','system'), (159,203,'BUTTON','','','发布 OAuth2 认证方式','{"perm":"gateway:oauth2-client:update"}',1,now(),now(),'system','system'), (164,205,'BUTTON','','','发布网关全局过滤器','{"perm":"gateway:filter:update"}',1,now(),now(),'system','system'),
-       (221,220,'BUTTON','','','轮换内部 Token 密钥','{"perm":"sysadmin:internal-token-key:rotate"}',1,now(),now(),'system','system'), (222,220,'BUTTON','','','退役 previous 密钥','{"perm":"sysadmin:internal-token-key:retire"}',2,now(),now(),'system','system'), (231,110,'BUTTON','','','终止 OAuth2 服务端授权','{"perm":"auth:authorization:revoke"}',1,now(),now(),'system','system');
+       (221,220,'BUTTON','','','轮换内部 Token 密钥','{"perm":"sysadmin:internal-token-key:rotate"}',1,now(),now(),'system','system'), (222,220,'BUTTON','','','退役 previous 密钥','{"perm":"sysadmin:internal-token-key:retire"}',2,now(),now(),'system','system'), (231,110,'BUTTON','','','终止 OAuth2 服务端授权','{"perm":"auth:authorization:revoke"}',1,now(),now(),'system','system'), (232,110,'BUTTON','','','清理已失效 Token','{"perm":"auth:authorization:cleanup"}',2,now(),now(),'system','system');
 
 INSERT INTO base_org_role_menu (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
 SELECT 100000 + r.id * 1000 + m.id, r.id, m.id, now(), now(), 'system', 'system'
@@ -421,4 +424,4 @@ ON DUPLICATE KEY UPDATE updated_time=VALUES(updated_time), updated_by=VALUES(upd
 INSERT INTO base_org_role_menu (id, role_id, menu_id, created_time, updated_time, created_by, updated_by)
 SELECT 100000 + r.id * 1000 + m.id, r.id, m.id, now(), now(), 'system', 'system'
 FROM base_org_menu m JOIN base_org_role r ON r.id IN (101, 103)
-WHERE m.id IN (122, 123, 220, 221, 222, 231) OR m.id BETWEEN 130 AND 159;
+WHERE m.id IN (122, 123, 220, 221, 222, 231, 232) OR m.id BETWEEN 130 AND 159;


### PR DESCRIPTION
## 变更
- 内部 Token 管理改名为内部认证
- 新增清理失效 Token 的按钮与 API 权限
- 增加幂等数据库迁移并同步初始化 DDL

## 验证
- MenuServiceTest 通过
- diff check 通过