### PR TITLE
升级 Framework 至 0.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>opensabre-base-dependencies</artifactId>
         <groupId>io.github.opensabre</groupId>
-        <version>0.7.0</version>
+        <version>0.7.1</version>
     </parent>
 
     <artifactId>base-organization</artifactId>


### PR DESCRIPTION
## 变更\n- 将 OpenSabre Framework BOM/显式 starter 版本从 0.7.0 升级至 0.7.1\n\n## 验证\n- `mvn --batch-mode --no-transfer-progress verify` 通过\n\n0.7.1 已发布至 Maven Central。